### PR TITLE
Add Variables to manifest.yml

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,12 +1,14 @@
 ---
 # This manifest deploys a Python Flask application with a Cloudant database
+# The same manifest will be used for both dev and prod deployment.
+# Please use `--var` during `cf push` to substitute `appname` and `route` to specific value
 applications:
-- name: nyu-shopcart-service-f20
+- name: ((appname))
   path: .
   instances: 1
   memory: 512M
   routes:
-  - route: nyu-shopcart-service-f20.us-south.cf.appdomain.cloud
+  - route: ((route))
   disk_quota: 1024M
   buildpacks:
   - python_buildpack


### PR DESCRIPTION
To use the same `manifest.yml` file for both `dev` and `prod`, we need to add two variables `appname` and `route` to `manifest.yml`. 

After that, we can use `ic cf push --var appname=... --var route=...` to define a specific environment.

## Checklist:

- [x] I have attached this PR to an issue/user story
